### PR TITLE
Update ThePirateBayTorrentProvider.cs

### DIFF
--- a/Novaroma.Services/ThePirateBay/ThePirateBayTorrentProvider.cs
+++ b/Novaroma.Services/ThePirateBay/ThePirateBayTorrentProvider.cs
@@ -99,7 +99,7 @@ namespace Novaroma.Services.ThePirateBay {
                 : excludeKeywords.Split(' ').Select(e => e.Trim()).Where(e => !string.IsNullOrEmpty(e)).Distinct().ToList();
 
             var results = new List<TorrentSearchResult>();
-            var url = Helper.CombineUrls(Settings.BaseUrl, "index.php?q=", search);
+            var url = Helper.CombineUrls(Settings.BaseUrl, "", search);
             using (var client = new NovaromaWebClient()) {
                 var html = await client.DownloadStringTaskAsync(url);
 


### PR DESCRIPTION
Removed hardcoded search string from the Pirate Bay torrent provider. It can be entered through the UI torrent provider config screen.  Allows for using proxies with different format of the search url.